### PR TITLE
Derive clone trait for Private and Signature

### DIFF
--- a/keys/src/private.rs
+++ b/keys/src/private.rs
@@ -10,7 +10,7 @@ use crypto::{checksum, ChecksumType};
 use {Secret, DisplayLayout, Error, Message, Signature};
 
 /// Secret with additional network prefix and format type
-#[derive(Default, PartialEq)]
+#[derive(Default, PartialEq, Clone)]
 pub struct Private {
 	/// The network prefix on which this key should be used.
 	pub prefix: u8,

--- a/keys/src/signature.rs
+++ b/keys/src/signature.rs
@@ -7,7 +7,7 @@ use hex::{ToHex, FromHex};
 use hash::H520;
 use Error;
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Clone)]
 pub struct Signature(Vec<u8>);
 
 impl fmt::Debug for Signature {


### PR DESCRIPTION
Needed to add this trait in order to use these objects as part of a struct with [pyo3](https://github.com/PyO3/pyo3).  